### PR TITLE
check if worker node count is 0 and report error

### DIFF
--- a/pkg/controller/iperf/iperf_controller.go
+++ b/pkg/controller/iperf/iperf_controller.go
@@ -124,6 +124,10 @@ func (r *ReconcileIperf) Reconcile(request reconcile.Request) (reconcile.Result,
 		return reconcile.Result{}, err
 	}
 
+	if len(workerNodeList.Items) == 0 {
+		return reconcile.Result{}, fmt.Errorf("could not find at least one worker node")
+	}
+
 	// Fetch configuration for iPerf client/server's
 	sessionDuration := strconv.Itoa(cr.Spec.SessionDuration / len(workerNodeList.Items))
 	concurrentConnections := strconv.Itoa(cr.Spec.ConcurrentConnections / len(workerNodeList.Items))

--- a/pkg/controller/iperf/iperf_controller.go
+++ b/pkg/controller/iperf/iperf_controller.go
@@ -125,7 +125,7 @@ func (r *ReconcileIperf) Reconcile(request reconcile.Request) (reconcile.Result,
 	}
 
 	if len(workerNodeList.Items) == 0 {
-		return reconcile.Result{}, fmt.Errorf("could not find at least one worker node")
+		return reconcile.Result{Requeue: false}, fmt.Errorf("could not find at least one worker node")
 	}
 
 	// Fetch configuration for iPerf client/server's


### PR DESCRIPTION
Tested this on a k8s local cluster which didnt have the node label. workerNodeList.Items was 0 and this resulted in a division by zero on line 131

Ultimately we should enable setting a different node label key & value via command line arguments or in the CR. 