### PR TITLE
Implement test servers and clients

### DIFF
--- a/pkg/controller/iperf/iperf_controller.go
+++ b/pkg/controller/iperf/iperf_controller.go
@@ -59,13 +59,13 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 	// // TODO(user): Modify this to be the types you create that are owned by the primary resource
 	// // Watch for changes to secondary resource Pods and requeue the owner Iperf
-	// err = c.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForOwner{
-	// 	IsController: true,
-	// 	OwnerType:    &iperfv1alpha1.Iperf{},
-	// })
-	// if err != nil {
-	// 	return err
-	// }
+	err = c.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForOwner{
+		IsController: true,
+		OwnerType:    &iperfv1alpha1.Iperf{},
+	})
+	if err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -170,7 +170,7 @@ func (r *ReconcileIperf) Reconcile(request reconcile.Request) (reconcile.Result,
 
 		time.Sleep(time.Duration(10 * time.Second))
 		// Get server pod IP to pass to iPerf clients
-		iperfServerIP, err := r.getServerPodIP(namespacedName)
+		iperfServerIP, err := r.getPodIP(namespacedName)
 		if err != nil {
 			if errors.IsNotFound(err) {
 				// Request object not found, object my not be ready yet
@@ -242,13 +242,89 @@ func (r *ReconcileIperf) Reconcile(request reconcile.Request) (reconcile.Result,
 		}
 		// Continue as client pod alraedy exists
 	}
-
 	reqLogger.Info("Server and clients created")
+
+	// Test servers and clients
+	reqLogger.Info("Creating test servers and clients")
+	testServers := make(map[string]string)
+	for _, label := range workerNodeLabels {
+		serverNamePrefix := "testserver-"
+		namespacedName := types.NamespacedName{
+			Name:      fmt.Sprintf("%s%s", serverNamePrefix, label),
+			Namespace: request.Namespace,
+		}
+		// Create testserver pod on worker node
+		testServerPod := generateTestServerPod(namespacedName, label)
+
+		// Set Iperf instance as the owner and controller
+		if err := controllerutil.SetControllerReference(cr, testServerPod, r.scheme); err != nil {
+			return reconcile.Result{}, err
+		}
+
+		// Check if a testserver pod already exists
+		found := &corev1.Pod{}
+		err = r.client.Get(context.TODO(), types.NamespacedName{Name: namespacedName.Name, Namespace: namespacedName.Namespace}, found)
+		if err != nil && errors.IsNotFound(err) {
+			reqLogger.Info("Creating a new testserver Pod", "testServerPod.Namespace", testServerPod.Namespace, "testServerPod.Name", testServerPod.Name, "iperServerPodWorkerLabel", label)
+			err = r.client.Create(context.TODO(), testServerPod)
+			if err != nil {
+				return reconcile.Result{}, err
+			}
+		} else if err != nil {
+			return reconcile.Result{}, err
+		}
+
+		time.Sleep(time.Duration(10 * time.Second))
+		// Get testserver pod IP to pass to test clients
+		testServerIP, err := r.getPodIP(namespacedName)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				// Request object not found, object my not be ready yet
+				// TODO: Wait for object to exist instead of requeuing in time
+				// Log that the object was not found and that we are requeuing (Assuming it'll exist in the future)
+				reqLogger.Info(fmt.Sprintf("Unable to find pod %s retrying in %d", namespacedName.Name, requeueWaitTime))
+				return reconcile.Result{RequeueAfter: requeueWaitTime}, nil
+			}
+			// Error reading the object - requeue the request.
+			return reconcile.Result{}, err
+		}
+
+		testServers[label] = *testServerIP
+	}
+	reqLogger.Info("Finished creating test servers")
+
+	for label, testServerIP := range testServers {
+		clientNamePrefix := "testclient-"
+		namespacedName := types.NamespacedName{
+			Name:      fmt.Sprintf("%s%s", clientNamePrefix, label),
+			Namespace: request.Namespace,
+		}
+		testClientPod := generateTestClientPod(namespacedName, label, testServerIP)
+
+		// Set Iperf instance as the owner and controller
+		if err := controllerutil.SetControllerReference(cr, testClientPod, r.scheme); err != nil {
+			return reconcile.Result{}, err
+		}
+
+		// Check if a test client pod already exists
+		found := &corev1.Pod{}
+		err = r.client.Get(context.TODO(), types.NamespacedName{Name: namespacedName.Name, Namespace: namespacedName.Namespace}, found)
+		if err != nil && errors.IsNotFound(err) {
+			reqLogger.Info("Creating a new testclient Pod", "testClientPod.Namespace", testClientPod.Namespace, "testClientPod.Name", testClientPod.Name, "iperClientPodWorkerLabel", label, "testServerIP", testServerIP)
+			err = r.client.Create(context.TODO(), testClientPod)
+			if err != nil {
+				return reconcile.Result{}, err
+			}
+		} else if err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+	reqLogger.Info("Finished creating test clients")
 
 	return reconcile.Result{}, nil
 }
 
-func (r *ReconcileIperf) getServerPodIP(namespacedName types.NamespacedName) (*string, error) {
+func (r *ReconcileIperf) getPodIP(namespacedName types.NamespacedName) (*string, error) {
 
 	pod := &corev1.Pod{}
 	err := r.client.Get(context.TODO(), namespacedName, pod)


### PR DESCRIPTION
This adds the following to the iperf reconcile loop
- Create servers using `gcr.io/google_containers/echoserver`, which is a simple webserver that echoes back some headers test data to the client
- Create clients using `curlimages/curl:7.70.0`. This was the simplest way to get a recent curl version which allows outputing transfer information as json using `--write-out`.
- Client runs curl on a timer which outputs information to stdout (container logs) as json we can parse.
- Enables watching of Pod objects so we can requeue if some resources are missing

```json
{
  "url_effective": "http://10.244.0.8:8080/",
  "http_code": 200,
  "response_code": 200,
  "http_connect": 0,
  "time_total": 0.000272,
  "time_namelookup": 2e-05,
  "time_connect": 0.000105,
  "time_appconnect": 0,
  "time_pretransfer": 0.000136,
  "time_starttransfer": 0.000247,
  "size_header": 156,
  "size_request": 83,
  "size_download": 294,
  "size_upload": 0,
  "speed_download": 294000,
  "speed_upload": 0,
  "content_type": "text/plain",
  "num_connects": 1,
  "time_redirect": 0,
  "num_redirects": 0,
  "ssl_verify_result": 0,
  "proxy_ssl_verify_result": 0,
  "filename_effective": "/dev/null",
  "remote_ip": "10.244.0.8",
  "remote_port": 8080,
  "local_ip": "10.244.0.19",
  "local_port": 50592,
  "http_version": "1.1",
  "scheme": "HTTP",
  "curl_version": "libcurl/7.70.0-DEV OpenSSL/1.1.1d zlib/1.2.11 libssh2/1.9.0 nghttp2/1.40.0"
}
```

This is a bit rough at the moment but seem to be working as intended. 